### PR TITLE
Make repo gh-pages deployable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# ignore generated .pdf
-# all pdf in the root folder are untracked
-# put pdf sources into a subfolder
-/*.pdf
-# ignore page
-/index.html
+# ignore typesetted document
+/hackers-delight.pdf
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 # ignore typesetted document
 /hackers-delight.pdf
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,19 +14,13 @@ before_install:
 
 script:
   - docker run tectonic "$TRAVIS_REPO_NAME".tex
-  # Move typesetted document
-  - mkdir $TRAVIS_BUILD_ID
-  - mv "$TRAVIS_REPO_NAME".pdf $TRAVIS_BUILD_ID
 
 deploy:
   provider: pages
   skip-cleanup: true
   github-token: $GITHUB_TOKEN
-  # Keep older versions
+  # Keep older versions to browse
   keep-history: true
   # Only publish master
   on:
     branch: master
-  # Only push files moved earlier
-  localdir: $TRAVIS_BUILD_ID
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 
 script:
   # overwrite files
-  - mv -rf /gh-pages/* .
+  - mv -f /gh-pages/* .
   # run tectonic
   - docker run --mount src=$TRAVIS_BUILD_DIR,target=/usr/src/tex,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic $TRAVIS_REPO_NAME.tex"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ before_install:
   - docker pull dxjoke/tectonic-docker
 
 script:
+  # overwrite files
+  - mv -rf /gh-pages/* .
+  # run tectonic
   - docker run --mount src=$TRAVIS_BUILD_DIR,target=/usr/src/tex,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic $TRAVIS_REPO_NAME.tex"
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - docker pull dxjoke/tectonic-docker
 
 script:
-  - docker run --mount src=$TRAVIS_BUILD_DIR,target=/usr/,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic $TRAVIS_REPO_NAME.tex"
+  - docker run --mount src=$TRAVIS_BUILD_DIR,target=/usr/src/tex,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic $TRAVIS_REPO_NAME.tex"
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ after_success: |
   if [ -n "$GITHUB_API_KEY" ]; then
     cd "$TRAVIS_BUILD_DIR"
     git init
+    git fetch
     git checkout artifacts
     git add .
     git -c user.name='travis' -c user.email='travis' commit -m init

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,17 @@ script:
     
 after_success: |
   if [ -n "$GITHUB_API_KEY" ]; then
-    git clone https://github.com/LucasForster/hackers-delight/ "$TRAVIS_BUILD_DIR"
     cd "$TRAVIS_BUILD_DIR"
+    ls
+    git clone https://github.com/LucasForster/hackers-delight/ "$TRAVIS_BUILD_DIR"
+    cd hackers-delight
     git checkout artifacts
+    rm -rf
+    mv ../hackers-delight.pdf .
+    ls
     git add .
     git -c user.name='travis' -c user.email='travis' commit -m init
     # Make sure to make the output quiet, or else the API token will leak!
     # This works because the API key can replace your password.
     git push -f -q https://LucasForster:$GITHUB_API_KEY@github.com/LucasForster/hackers-delight-gh-pages gh-pages &>/dev/null
-    cd "$TRAVIS_BUILD_DIR"
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,19 @@ language: generic
 services: docker
 
 script:
-    # We use the docker image from https://hub.docker.com/r/dxjoke/tectonic-docker/
-    # Compiling only main.tex:
-    - docker run --mount src=$TRAVIS_BUILD_DIR,target=/usr/src/tex,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic hackers-delight.tex"
+  # We use the docker image from https://hub.docker.com/r/dxjoke/tectonic-docker/
+  # Compiling only main.tex:
+  - docker run --mount src=$TRAVIS_BUILD_DIR,target=/usr/src/tex,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic hackers-delight.tex"
     
-deploy:
-    provider: releases
-    api_key:
-        secure: GK0T9i6YKZlKmxurW4B8lkBGCfUcehODrWA8VcuUaK4CgSYaVj2BzMJj4E7pA3Ucm76bGR9l1yWYA+RHRwg0033A8Tw54hIinAcwiuXCpRwgcVkbbxK77o8Q4g0ooRPAMePtkQrjeq1JgHN2sZUZ2CixhtCDApM8H4yaQW7bb7TmBFut/9YEfiJVBCAE0ZNjbjXSbYADRc9Zh1fy/53xJzgKC57dQnFDrnEsGlwRkrv5lQK+3Dw7ktd48pQe8C3c2LNZn052gaR0TxxzDBAyvG4nmeA17wYMvZk7UhfKYVdqUjNqwyjktvWQQDOAtWL7OrlBNfWyf5bEn1RsfsnZ7lX/3uTj1z2fQeaYcx29goSo6y7cemz+UFsuoG3ggMuD1V81xkLI82WglYnbDEd7wij5kj1+/YAliiiZtO98kLUXbyPKWq0ycmPjj1PKyiX1Gk4LMtPfvDEIdhm/uShCY+6PrOxnGPAEd+gKgA8kAdhkuZ1/IZjkbz0dQpoZgJse7V71x+cop8fvHsuFUcj/irk4qzfVkfhnKuNpMtq2z6HDvQ/GDkZKUTkNaok8rWGFGhE8TiXCoaEoWUASEQcqouQY8KHjqQT6JVgKLwsoPuA34Pb5Fb6tbFzrNT5QE7GTeoVa9GPXJ3IrKepdcRAo3I8GVEyH0rWItdWBH0tU7fo=
-    file:
-        - ./src/biber-mwe.pdf
-        - ./src/main.pdf
-    skip_cleanup: true
-    on:
-        tags: true
-        branch: master
+after_success: |
+  if [ -n "$GITHUB_API_KEY" ]; then
+    cd "$TRAVIS_BUILD_DIR"
+    git init
+    git checkout -b gh-pages
+    git add .
+    git -c user.name='travis' -c user.email='travis' commit -m init
+    # Make sure to make the output quiet, or else the API token will leak!
+    # This works because the API key can replace your password.
+    git push -f -q https://LucasForster:$GITHUB_API_KEY@github.com/LucasForster/hackers-delight-gh-pages gh-pages &>/dev/null
+    cd "$TRAVIS_BUILD_DIR"
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ script:
 deploy:
   provider: pages
   skip-cleanup: true
-  github-token: $GITHUB_TOKEN
+  github-token: $GH_TOKEN
   local-dir: gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
 
 script:
   - docker run --mount src=$TRAVIS_BUILD_DIR,target=/usr/src/tex,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic $TRAVIS_REPO_NAME.tex"
+  - rm -f $TRAVIS_BUILD_DIR/.gitignore
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ before_install:
   - docker pull dxjoke/tectonic-docker
 
 script:
-  - docker run "tectonic $TRAVIS_REPO_NAME.tex"
+  - docker run tectonic "$TRAVIS_REPO_NAME".tex
   # Move typesetted document
   - mkdir $TRAVIS_BUILD_ID
-  - mv $TRAVIS_REPO_NAME.tex $TRAVIS_BUILD_ID
+  - mv "$TRAVIS_REPO_NAME".pdf $TRAVIS_BUILD_ID
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ deploy:
   skip-cleanup: true
   github-token: $GH_TOKEN
   local-dir: gh-pages
+  keep-history: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ before_install:
   - docker pull dxjoke/tectonic-docker
 
 script:
-  # overwrite files
-  - mv -f /gh-pages/* .
   # run tectonic
   - docker run --mount src=$TRAVIS_BUILD_DIR,target=/usr/src/tex,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic $TRAVIS_REPO_NAME.tex"
+  # overwrite files
+  - docker run /bin/sh -c "mv -f /gh-pages/* ."
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ after_success: |
     git -c user.name='travis' -c user.email='travis' commit -m init
     # Make sure to make the output quiet, or else the API token will leak!
     # This works because the API key can replace your password.
-    git push -f -q https://LucasForster:$GITHUB_API_KEY@github.com/LucasForster/hackers-delight-gh-pages gh-pages &>/dev/null
+    git push -f -q https://LucasForster:$GITHUB_API_KEY@github.com/LucasForster/hackers-delight-artifacts artifacts &>/dev/null
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ after_success: |
   if [ -n "$GITHUB_API_KEY" ]; then
     cd "$TRAVIS_BUILD_DIR"
     git init
-    git checkout -b gh-pages
+    git checkout artifacts
     git add .
     git -c user.name='travis' -c user.email='travis' commit -m init
     # Make sure to make the output quiet, or else the API token will leak!

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,28 +2,18 @@ sudo: required
 
 language: generic
 
-env:
-  global:
-    - TRAVIS_REPO_NAME=${TRAVIS_REPO_SLUG#*/}
-
 services:
   - docker
 
-before_install:
+install:
   - docker pull dxjoke/tectonic-docker
 
 script:
-  # run tectonic
-  - docker run --mount src=$TRAVIS_BUILD_DIR,target=/usr/src/tex,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic $TRAVIS_REPO_NAME.tex"
-  # overwrite files
-  - docker run /bin/sh -c "mv -f /gh-pages/* ."
+  - docker run --mount src=$TRAVIS_BUILD_DIR,target=/usr/src/tex,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic hackers-delight.tex"
+  - cp hackers-delight.pdf gh-pages/hackers-delight.pdf
 
 deploy:
   provider: pages
   skip-cleanup: true
   github-token: $GITHUB_TOKEN
-  # Keep older versions to browse
-  keep-history: true
-  # Only publish master
-  on:
-    branch: master
+  local-dir: gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,32 @@
 sudo: required
-language: generic
-services: docker
 
-git:
-  quiet: true
+language: generic
+
+env:
+  global:
+    - TRAVIS_REPO_NAME=${TRAVIS_REPO_SLUG#*/}
+
+services:
+  - docker
+
+before_install:
+  - docker pull dxjoke/tectonic-docker
 
 script:
-  # Docker image from https://hub.docker.com/r/dxjoke/tectonic-docker/
-  # Compiling only main.tex:
-  - docker run --mount src=$TRAVIS_BUILD_DIR,target=/usr/src/tex,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic hackers-delight.tex"
+  - docker run "tectonic $TRAVIS_REPO_NAME.tex"
+  # Move typesetted document
+  - mkdir $TRAVIS_BUILD_ID
+  - mv $TRAVIS_REPO_NAME.tex $TRAVIS_BUILD_ID
 
 deploy:
   provider: pages
   skip-cleanup: true
-  github-token: $GITHUB_API_KEY
+  github-token: $GITHUB_TOKEN
   # Keep older versions
   keep-history: true
   # Only publish master
   on:
     branch: master
+  # Only push files moved earlier
+  localdir: $TRAVIS_BUILD_ID
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - docker pull dxjoke/tectonic-docker
 
 script:
-  - docker run --mount src=$TRAVIS_BUILD_DIR/src,target=/usr/src/tex,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic $TRAVIS_REPO_NAME.tex"
+  - docker run --mount src=$TRAVIS_BUILD_DIR,target=/usr/,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic $TRAVIS_REPO_NAME.tex"
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,20 @@ sudo: required
 language: generic
 services: docker
 
+git:
+  quiet: true
+
 script:
-  # We use the docker image from https://hub.docker.com/r/dxjoke/tectonic-docker/
+  # Docker image from https://hub.docker.com/r/dxjoke/tectonic-docker/
   # Compiling only main.tex:
   - docker run --mount src=$TRAVIS_BUILD_DIR,target=/usr/src/tex,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic hackers-delight.tex"
-    
-after_success: |
-  if [ -n "$GITHUB_API_KEY" ]; then
-    cd "$TRAVIS_BUILD_DIR"
-    git clone https://github.com/LucasForster/hackers-delight/ artifacts
-    cd artifacts
-    git checkout artifacts
-    rm -rf
-    mv ../hackers-delight.pdf .
-    git add .
-    git -c user.name='travis' -c user.email='travis' commit -m init
-    # Make sure to make the output quiet, or else the API token will leak!
-    # This works because the API key can replace your password.
-    git push -f -q https://LucasForster:$GITHUB_API_KEY@github.com/LucasForster/hackers-delight-artifacts artifacts &>/dev/null
-  fi
+
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_API_KEY
+  # Keep older versions
+  keep-history: true
+  # Only publish master
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ script:
     
 after_success: |
   if [ -n "$GITHUB_API_KEY" ]; then
+    git clone https://github.com/LucasForster/hackers-delight/ "$TRAVIS_BUILD_DIR"
     cd "$TRAVIS_BUILD_DIR"
-    git init
-    git fetch
     git checkout artifacts
     git add .
     git -c user.name='travis' -c user.email='travis' commit -m init

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ script:
 deploy:
   provider: pages
   skip-cleanup: true
-  github-token: $GH_TOKEN
-  local-dir: gh-pages
+  github-token: $GITHUB_TOKEN
   keep-history: true
+  local-dir: gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,11 @@ script:
 after_success: |
   if [ -n "$GITHUB_API_KEY" ]; then
     cd "$TRAVIS_BUILD_DIR"
-    ls
-    git clone https://github.com/LucasForster/hackers-delight/ "$TRAVIS_BUILD_DIR"
-    cd hackers-delight
+    git clone https://github.com/LucasForster/hackers-delight/ artifacts
+    cd artifacts
     git checkout artifacts
     rm -rf
     mv ../hackers-delight.pdf .
-    ls
     git add .
     git -c user.name='travis' -c user.email='travis' commit -m init
     # Make sure to make the output quiet, or else the API token will leak!

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - docker pull dxjoke/tectonic-docker
 
 script:
-  - docker run tectonic "$TRAVIS_REPO_NAME".tex
+  - docker run --mount src=$TRAVIS_BUILD_DIR/src,target=/usr/src/tex,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic $TRAVIS_REPO_NAME.tex"
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_install:
 
 script:
   - docker run --mount src=$TRAVIS_BUILD_DIR,target=/usr/src/tex,type=bind dxjoke/tectonic-docker /bin/sh -c "tectonic $TRAVIS_REPO_NAME.tex"
-  - rm -f $TRAVIS_BUILD_DIR/.gitignore
 
 deploy:
   provider: pages

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://api.travis-ci.com/LucasForster/hackers-delight.svg)](https://travis-ci.com/LucasForster/hackers-delight)
+
 [Read the PDF on GitHub Pages](https://lucasforster.github.io/hackers-delight/)
 # Hacker's Delight
 This term paper provides introductionary explanations on Henry Warren's Book "Hacker's Delight".

--- a/gh-pages/.gitignore
+++ b/gh-pages/.gitignore
@@ -1,6 +1,0 @@
-# ignore everything...
-*
-# except typesetted document
-!/hackers-delight.pdf
-# except site
-!/index.html

--- a/gh-pages/.gitignore
+++ b/gh-pages/.gitignore
@@ -1,0 +1,6 @@
+# ignore everything...
+*
+# except typesetted document
+!/hackers-delight.pdf
+# except site
+!/index.html

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>Hacker's Delight</title>
+</head>
+
+<style>
+    body {
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+        margin: 0;
+    }
+
+    embed {
+        flex-grow: 1;
+    }
+</style>
+
+<body>
+    <embed
+        src="hackers-delight.pdf"
+        type="application/pdf"
+    />
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>Hacker's Delight</title>
+</head>
+
+<style>
+    body {
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+        margin: 0;
+    }
+
+    embed {
+        flex-grow: 1;
+    }
+</style>
+
+<body>
+    <embed
+        src="hackers-delight.pdf"
+        type="application/pdf"
+    />
+</body>
+
+</html>


### PR DESCRIPTION
Keeps history, deploys using the index.html found in gh-pages.

Removed some "superfluous" or "over the top" config (less is more in this case).